### PR TITLE
the include directory is missing from the installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,12 @@ elseif (MACOSX)
             COMPONENT devel)
 endif()
 
+# Copy include directory to install location
+install(
+	DIRECTORY include
+	DESTINATION .
+)
+
 
 # Define the libraries sfe should link against
 target_link_libraries (${LIB_NAME} ${SFML_LIBRARIES} ${FFMPEG_LIBRARIES} ${OTHER_LIBRARIES})


### PR DESCRIPTION
The include directory and the relevant .hpp file is missing when you do an installation.  This is fixed via CMake.
