### PR TITLE
prevent error for "rm" when folder is empty

### DIFF
--- a/build_ffmpeg.sh
+++ b/build_ffmpeg.sh
@@ -89,6 +89,7 @@ function build_ffmpeg()
 		fi
         
 	    mkdir -p ../ffmpeg-build
+		touch ../ffmpeg-build/build_dir.txt
 		rm ../ffmpeg-build/*
 	    
 		echo "Copying libraries into ffmpeg-build"


### PR DESCRIPTION
This fixes the issue with the directory being empty by creating a temporary file there.  Another alternative would be to use the -f option for "rm" (I think).
