### PR TITLE
Fix FFmpeg building

### DIFF
--- a/build_ffmpeg.sh
+++ b/build_ffmpeg.sh
@@ -162,7 +162,6 @@ function main()
 
             shift
             shift
-            shift
             full_decoders_list="$*"
             
             echo "Build directory : ${build_dir}"


### PR DESCRIPTION
The first codec in the list was always shifted away. I tested this on Windows with MSVC, not sure if other OSes even use this.