### PR TITLE
faster check for empty status

### DIFF
--- a/src/Demuxer.cpp
+++ b/src/Demuxer.cpp
@@ -604,7 +604,7 @@ namespace sfe
         if (m_connectedSubtitleStream)
             connectedStreams.insert(m_connectedSubtitleStream);
         
-        CHECK(connectedStreams.size() > 0, "Inconcistency error: seeking with no active stream");
+        CHECK(!connectedStreams.empty(), "Inconcistency error: seeking with no active stream");
         
         // Trivial seeking to beginning
         if (newPosition == sf::Time::Zero)

--- a/src/MovieImpl.cpp
+++ b/src/MovieImpl.cpp
@@ -65,14 +65,14 @@ namespace sfe
             m_demuxer->selectFirstAudioStream();
             m_demuxer->selectFirstVideoStream();
             
-            if (!audioStreams.size() && !videoStreams.size())
+            if (audioStreams.empty() && videoStreams.empty())
             {
                 sfeLogError("Movie::openFromFile() - No supported audio or video stream in this media");
                 return false;
             }
             else
             {
-                if (videoStreams.size())
+                if (!videoStreams.empty())
                 {
                     sf::Vector2f size = getSize();
                     m_displayFrame = sf::FloatRect(0, 0, size.x, size.y);
@@ -507,7 +507,7 @@ namespace sfe
     void MovieImpl::didUpdateSubtitle(const SubtitleStream& sender, const std::list<sf::Sprite>& subs, const std::list<sf::Vector2i>& positions)
     {
         m_subtitleSprites = subs;
-        bool use_position = positions.size() > 0;
+        bool use_position = !positions.empty();
         sf::Vector2f subtitlesCenter(m_displayFrame.left + m_displayFrame.width / 2,
                                      m_displayFrame.top + m_displayFrame.height * 0.9f);
         std::list<sf::Vector2i>::const_iterator pos_it = positions.begin();
@@ -543,7 +543,7 @@ namespace sfe
             m_debugger.bind(&subtitleSprite);
         }
         
-        if (m_subtitleSprites.size() == 0)
+        if (m_subtitleSprites.empty())
             m_debugger.bind(nullptr);
     }
     

--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -121,12 +121,12 @@ namespace sfe
         AVPacket* result = nullptr;
         sf::Lock l(m_readerMutex);
         
-        if (!m_packetList.size() && !isPassive())
+        if (m_packetList.empty() && !isPassive())
         {
             m_dataSource.requestMoreData(*this);
         }
         
-        if (m_packetList.size())
+        if (!m_packetList.empty())
         {
             result = m_packetList.front();
             m_packetList.pop_front();
@@ -161,7 +161,7 @@ namespace sfe
         
         AVPacket* pkt = nullptr;
         
-        while (m_packetList.size())
+        while (!m_packetList.empty())
         {
             pkt = m_packetList.front();
             m_packetList.pop_front();
@@ -193,13 +193,9 @@ namespace sfe
     
     sf::Time Stream::computeEncodedPosition()
     {
-        if (!m_packetList.size())
+        if (m_packetList.empty())
         {
             m_dataSource.requestMoreData(*this);
-        }
-        
-        if (!m_packetList.size())
-        {
             return sf::Time::Zero;
         }
         else
@@ -288,6 +284,6 @@ namespace sfe
     
     bool Stream::hasPackets()
     {
-        return m_packetList.size() > 0;
+        return !m_packetList.empty();
     }
 }

--- a/src/SubtitleStream.cpp
+++ b/src/SubtitleStream.cpp
@@ -71,7 +71,7 @@ namespace sfe
                 setStatus(Stopped);
         }
         
-        if (m_pendingSubtitles.size() > 0)
+        if (!m_pendingSubtitles.empty())
         {
             //activate subtitle
             if (m_pendingSubtitles.front()->start < m_timer->getOffset())
@@ -85,7 +85,7 @@ namespace sfe
         }
         
         
-        if (m_visibleSubtitles.size()>0)
+        if (!m_visibleSubtitles.empty())
         {
             //remove subtitle
             if (m_visibleSubtitles.front()->end < m_timer->getOffset())
@@ -93,7 +93,7 @@ namespace sfe
                 std::shared_ptr<SubtitleData> subtitle = m_visibleSubtitles.front();
                 m_visibleSubtitles.pop_front();
                 
-                if (m_visibleSubtitles.size() == 0)
+                if (m_visibleSubtitles.empty())
                 {
                     m_delegate.didWipeOutSubtitles(*this);
                 }

--- a/tests/DemuxerTest.cpp
+++ b/tests/DemuxerTest.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(DemuxerLoadingTest)
 	
 	const std::map<int, std::shared_ptr<sfe::Stream> >& streams = demuxer->getStreams();
 	
-	BOOST_CHECK(streams.size() > 0);
+	BOOST_CHECK(!streams.empty());
 	
 	unsigned videoStreamCount = 0;
 	unsigned audioStreamCount = 0;


### PR DESCRIPTION
[cppcheck](http://cppcheck.sourceforge.net/) found these.  Basically, .empty() is a constant access speed whereas .size() is linear.  Probably not a huge deal but I think it's also easier to read.  As always, please double check this doesn't break anything. :)