### PR TITLE
fix bug when changing video offset while paused

### DIFF
--- a/src/VideoStream.cpp
+++ b/src/VideoStream.cpp
@@ -127,7 +127,7 @@ namespace sfe
             }
         }
         
-        if (! couldComputeGap)
+        if (! couldComputeGap && getStatus() == Playing)
         {
             setStatus(Stopped);
         }


### PR DESCRIPTION
This pull request fix a bug when changing the video offset while it's paused.
Currently, it just stop the video, returning to the beginning.

This is certainly due to this status check omission.
